### PR TITLE
Trees cache merging support

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -15,13 +15,11 @@ type (
 	LayerReadWriter = shared.LayerReadWriter
 	CacheWriter     = shared.CacheWriter
 	CacheReader     = shared.CacheReader
+	LayerFactory    = shared.LayerFactory
+	CachingPolicy   = shared.CachingPolicy
 )
 
 var RootHeightFromWidth = shared.RootHeightFromWidth
-
-type CachingPolicy func(layerHeight uint) (shouldCacheLayer bool)
-
-type LayerFactory func(layerHeight uint) (LayerReadWriter, error)
 
 type Writer struct {
 	*cache
@@ -99,6 +97,14 @@ func (c *Reader) GetLayerReader(layerHeight uint) LayerReader {
 
 func (c *Reader) GetHashFunc() HashFunc {
 	return c.hash
+}
+
+func (c *Reader) GetLayerFactory() LayerFactory {
+	return c.generateLayer
+}
+
+func (c *Reader) GetCachingPolicy() CachingPolicy {
+	return c.shouldCacheLayer
 }
 
 type cache struct {

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -3,15 +3,32 @@ package cache
 import (
 	"errors"
 	"fmt"
-	"github.com/spacemeshos/merkle-tree/cache/readwriters"
-	"math"
+	"github.com/spacemeshos/merkle-tree/shared"
 )
 
-const NodeSize = 32
+const NodeSize = shared.NodeSize
+
+type (
+	HashFunc        = shared.HashFunc
+	LayerWriter     = shared.LayerWriter
+	LayerReader     = shared.LayerReader
+	LayerReadWriter = shared.LayerReadWriter
+	CacheWriter     = shared.CacheWriter
+	CacheReader     = shared.CacheReader
+)
+
+var RootHeightFromWidth = shared.RootHeightFromWidth
+
+type CachingPolicy func(layerHeight uint) (shouldCacheLayer bool)
+
+type LayerFactory func(layerHeight uint) (LayerReadWriter, error)
 
 type Writer struct {
 	*cache
 }
+
+// A compile time check to ensure that Writer fully implements CacheWriter.
+var _ CacheWriter = (*Writer)(nil)
 
 func NewWriter(shouldCacheLayer CachingPolicy, generateLayer LayerFactory) *Writer {
 	return &Writer{
@@ -40,14 +57,14 @@ func (c *Writer) GetLayerWriter(layerHeight uint) (LayerWriter, error) {
 	return layerReadWriter, nil
 }
 
-func (c *Writer) SetHash(hashFunc func(lChild, rChild []byte) []byte) {
+func (c *Writer) SetHash(hashFunc HashFunc) {
 	c.hash = hashFunc
 }
 
 // GetReader returns a cache reader that can be passed into GenerateProof. It first flushes the layer writers to support
 // layer writers that have internal buffers that may not be reflected in the reader until flushed. After flushing, this
 // method validates the structure of the cache, including that a base layer is cached.
-func (c *Writer) GetReader() (*Reader, error) {
+func (c *Writer) GetReader() (CacheReader, error) {
 	if err := c.flush(); err != nil {
 		return nil, err
 	}
@@ -69,17 +86,24 @@ type Reader struct {
 	*cache
 }
 
+// A compile time check to ensure that Reader fully implements CacheReader.
+var _ CacheReader = (*Reader)(nil)
+
+func (c *Reader) Layers() map[uint]LayerReadWriter {
+	return c.layers
+}
+
 func (c *Reader) GetLayerReader(layerHeight uint) LayerReader {
 	return c.layers[layerHeight]
 }
 
-func (c *Reader) GetHashFunc() func(lChild, rChild []byte) []byte {
+func (c *Reader) GetHashFunc() HashFunc {
 	return c.hash
 }
 
 type cache struct {
 	layers           map[uint]LayerReadWriter
-	hash             func(lChild, rChild []byte) []byte
+	hash             HashFunc
 	shouldCacheLayer CachingPolicy
 	generateLayer    LayerFactory
 }
@@ -111,35 +135,6 @@ func (c *cache) validateStructure() error {
 		width >>= 1
 	}
 	return nil
-}
-
-type CachingPolicy func(layerHeight uint) (shouldCacheLayer bool)
-
-type LayerFactory func(layerHeight uint) (LayerReadWriter, error)
-
-// LayerReadWriter is a combined reader-writer. Note that the Seek() method only belongs to the LayerReader interface
-// and does not affect the LayerWriter.
-type LayerReadWriter interface {
-	LayerReader
-	LayerWriter
-}
-
-var _ LayerReadWriter = &readwriters.FileReadWriter{}
-var _ LayerReadWriter = &readwriters.SliceReadWriter{}
-
-type LayerReader interface {
-	Seek(index uint64) error
-	ReadNext() ([]byte, error)
-	Width() (uint64, error)
-}
-
-type LayerWriter interface {
-	Append(p []byte) (n int, err error)
-	Flush() error
-}
-
-func RootHeightFromWidth(width uint64) uint {
-	return uint(math.Ceil(math.Log2(float64(width))))
 }
 
 //func (c *cache) Print(bottom, top int) {

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -10,7 +10,8 @@ var someError = errors.New("some error")
 
 type widthReader struct{ width uint64 }
 
-var _ LayerReadWriter = &widthReader{}
+// A compile time check to ensure that widthReader fully implements LayerReadWriter.
+var _ LayerReadWriter = (*widthReader)(nil)
 
 func (r widthReader) Seek(index uint64) error            { return nil }
 func (r widthReader) ReadNext() ([]byte, error)          { return nil, someError }

--- a/cache/group.go
+++ b/cache/group.go
@@ -15,6 +15,7 @@ type GroupLayerReadWriter struct {
 // A compile time check to ensure that GroupLayerReadWriter fully implements LayerReadWriter.
 var _ LayerReadWriter = (*GroupLayerReadWriter)(nil)
 
+// groupLayers groups a slice of layers into one unified layer.
 func groupLayers(layers []LayerReadWriter) (*GroupLayerReadWriter, error) {
 	if len(layers) < 2 {
 		return nil, errors.New("number of layers must be at least 2")

--- a/cache/group.go
+++ b/cache/group.go
@@ -1,0 +1,102 @@
+package cache
+
+import (
+	"errors"
+	"io"
+)
+
+type GroupLayerReadWriter struct {
+	chunks           []LayerReadWriter
+	activeChunkIndex int
+	widthPerChunk    uint64
+	lastChunkWidth   uint64
+}
+
+// A compile time check to ensure that GroupLayerReadWriter fully implements LayerReadWriter.
+var _ LayerReadWriter = (*GroupLayerReadWriter)(nil)
+
+func groupLayers(layers []LayerReadWriter) (*GroupLayerReadWriter, error) {
+	if len(layers) < 2 {
+		return nil, errors.New("number of layers must be at least 2")
+	}
+
+	widthPerLayer, err := layers[0].Width()
+	if err != nil {
+		return nil, err
+	}
+	if widthPerLayer == 0 {
+		return nil, errors.New("0 width layers are not allowed")
+	}
+
+	// Verify that all layers, except the last one, have the same width.
+	var lastLayerWidth uint64
+	for i := 1; i < len(layers); i++ {
+		layer := layers[i]
+		if layer == nil {
+			return nil, errors.New("nil layers are not allowed")
+		}
+		width, err := layers[i].Width()
+		if err != nil {
+			return nil, err
+		}
+
+		if i == len(layers)-1 {
+			lastLayerWidth = width
+		} else {
+			if width != widthPerLayer && i < len(layers)-1 {
+				return nil, errors.New("layers width mismatch")
+			}
+		}
+	}
+
+	g := &GroupLayerReadWriter{
+		chunks:         layers,
+		widthPerChunk:  widthPerLayer,
+		lastChunkWidth: lastLayerWidth,
+	}
+
+	return g, nil
+}
+
+func (g *GroupLayerReadWriter) Seek(index uint64) error {
+	// Find the target chunk.
+	chunkIndex := int(index / g.widthPerChunk)
+	if chunkIndex >= len(g.chunks) {
+		return io.EOF
+	}
+
+	// Reset the previous active chunk position
+	// and set the new active chunk.
+	if g.activeChunkIndex != chunkIndex {
+		err := g.chunks[g.activeChunkIndex].Seek(0)
+		if err != nil {
+			return err
+		}
+
+		g.activeChunkIndex = chunkIndex
+	}
+
+	indexInChunk := index % g.widthPerChunk
+	return g.chunks[g.activeChunkIndex].Seek(indexInChunk)
+}
+
+func (g *GroupLayerReadWriter) ReadNext() ([]byte, error) {
+	val, err := g.chunks[g.activeChunkIndex].ReadNext()
+	if err != nil {
+		if err == io.EOF && g.activeChunkIndex < len(g.chunks)-1 {
+			g.activeChunkIndex++
+			return g.ReadNext()
+		}
+		return nil, err
+	}
+
+	return val, nil
+}
+
+func (g *GroupLayerReadWriter) Width() (uint64, error) {
+	return uint64(len(g.chunks)-1)*g.widthPerChunk + g.lastChunkWidth, nil
+}
+
+func (g *GroupLayerReadWriter) Append(p []byte) (n int, err error) { panic("not implemented") }
+
+func (g *GroupLayerReadWriter) Flush() error { panic("not implemented") }

--- a/cache/group_test.go
+++ b/cache/group_test.go
@@ -1,0 +1,157 @@
+package cache
+
+import (
+	"github.com/spacemeshos/merkle-tree/cache/readwriters"
+	"github.com/stretchr/testify/require"
+	"io"
+	"testing"
+)
+
+func TestGroupLayers(t *testing.T) {
+	r := require.New(t)
+
+	// Create 9 nodes.
+	nodes := genNodes(9)
+
+	// Split the nodes into 3 separate layers.
+	layers := make([]LayerReadWriter, 3)
+	layers[0] = &readwriters.SliceReadWriter{}
+	_, _ = layers[0].Append(nodes[0])
+	_, _ = layers[0].Append(nodes[1])
+	_, _ = layers[0].Append(nodes[2])
+	layers[1] = &readwriters.SliceReadWriter{}
+	_, _ = layers[1].Append(nodes[3])
+	_, _ = layers[1].Append(nodes[4])
+	_, _ = layers[1].Append(nodes[5])
+	layers[2] = &readwriters.SliceReadWriter{}
+	_, _ = layers[2].Append(nodes[6])
+	_, _ = layers[2].Append(nodes[7])
+	_, _ = layers[2].Append(nodes[8])
+
+	// Group the layers.
+	layer, err := groupLayers(layers)
+	r.NoError(err)
+
+	width, err := layer.Width()
+	r.NoError(err)
+	r.Equal(width, uint64(len(nodes)))
+
+	// Iterate over the layer.
+	for _, node := range nodes {
+		val, err := layer.ReadNext()
+		r.NoError(err)
+		r.Equal(val, node)
+	}
+
+	// Iterate over the layer with Seek.
+	for i, node := range nodes {
+		err := layer.Seek(uint64(i))
+		r.NoError(err)
+		val, err := layer.ReadNext()
+		r.NoError(err)
+		r.Equal(val, node)
+	}
+	_, err = layer.ReadNext()
+	r.Equal(err, io.EOF)
+
+	// Iterate over the layer with Seek in reverse.
+	for i := len(nodes) - 1; i >= 0; i-- {
+		err := layer.Seek(uint64(i))
+		r.NoError(err)
+		val, err := layer.ReadNext()
+		r.NoError(err)
+		r.Equal(val, nodes[i])
+	}
+
+	// Verify that deactivated chunk position is being reset.
+	// (target chunk 1 position 1)
+	err = layer.Seek(uint64(3))
+	r.NoError(err)
+	val, err := layer.ReadNext()
+	r.NoError(err)
+	r.Equal(val, nodes[3])
+	// (target chunk 0 position 2)
+	err = layer.Seek(uint64(2))
+	r.NoError(err)
+	val, err = layer.ReadNext()
+	r.NoError(err)
+	r.Equal(val, nodes[2])
+	// (target chunk 1 position 0)
+	val, err = layer.ReadNext()
+	r.NoError(err)
+	r.Equal(val, nodes[3])
+}
+
+func TestGroupLayersWithShorterLastLayer(t *testing.T) {
+	r := require.New(t)
+
+	// Create 7 nodes.
+	nodes := genNodes(7)
+
+	// Split the nodes into 3 separate layers in groups of [3,3,1].
+	layers := make([]LayerReadWriter, 3)
+	layers[0] = &readwriters.SliceReadWriter{}
+	_, _ = layers[0].Append(nodes[0])
+	_, _ = layers[0].Append(nodes[1])
+	_, _ = layers[0].Append(nodes[2])
+	layers[1] = &readwriters.SliceReadWriter{}
+	_, _ = layers[1].Append(nodes[3])
+	_, _ = layers[1].Append(nodes[4])
+	_, _ = layers[1].Append(nodes[5])
+	layers[2] = &readwriters.SliceReadWriter{}
+	_, _ = layers[2].Append(nodes[6])
+
+	// Group the layers.
+	layer, err := groupLayers(layers)
+	r.NoError(err)
+
+	width, err := layer.Width()
+	r.NoError(err)
+	r.Equal(width, uint64(len(nodes)))
+
+	// Iterate over the layer.
+	for _, node := range nodes {
+		val, err := layer.ReadNext()
+		r.NoError(err)
+		r.Equal(val, node)
+	}
+
+	// Arrive to EOF with ReadNext.
+	err = layer.Seek(uint64(6))
+	r.NoError(err)
+	val, err := layer.ReadNext()
+	r.NoError(err)
+	r.Equal(val, nodes[6])
+	val, err = layer.ReadNext()
+	r.Equal(io.EOF, err)
+
+	// Arrive to EOF with Seek.
+	err = layer.Seek(uint64(7))
+	r.Equal(io.EOF, err)
+	err = layer.Seek(uint64(666))
+	r.Equal(io.EOF, err)
+}
+
+func TestGroupLayersWithShorterMidLayer(t *testing.T) {
+	r := require.New(t)
+
+	// Create 7 nodes.
+	nodes := genNodes(7)
+
+	// Split the nodes into 3 separate layers in groups of [3,1,3].
+	layers := make([]LayerReadWriter, 3)
+	layers[0] = &readwriters.SliceReadWriter{}
+	_, _ = layers[0].Append(nodes[0])
+	_, _ = layers[0].Append(nodes[1])
+	_, _ = layers[0].Append(nodes[2])
+	layers[1] = &readwriters.SliceReadWriter{}
+	_, _ = layers[1].Append(nodes[3])
+	layers[2] = &readwriters.SliceReadWriter{}
+	_, _ = layers[2].Append(nodes[4])
+	_, _ = layers[2].Append(nodes[5])
+	_, _ = layers[2].Append(nodes[6])
+
+	// Group the layers.
+	_, err := groupLayers(layers)
+	r.Equal("layers width mismatch", err.Error())
+}

--- a/cache/merge.go
+++ b/cache/merge.go
@@ -6,6 +6,10 @@ import (
 	"io"
 )
 
+// Merge merges a slice of caches into one unified cache.
+// Layers of all caches per each height are appended and grouped, while
+// the hash function, caching policy and layer factory are taken
+// from the first cache of the slice.
 func Merge(caches []CacheReader) (*Reader, error) {
 	if len(caches) < 2 {
 		return nil, errors.New("number of caches must be at least 2")
@@ -46,6 +50,8 @@ func Merge(caches []CacheReader) (*Reader, error) {
 	return &Reader{cache}, nil
 }
 
+// BuildTop builds the top layers of a cache, and returns
+// its new version in addition to its root.
 func BuildTop(cacheReader CacheReader) (*Reader, []byte, error) {
 	// Find the cache highest layer.
 	var maxHeight uint

--- a/cache/merge.go
+++ b/cache/merge.go
@@ -61,13 +61,15 @@ func BuildTop(cacheReader CacheReader) (*Reader, []byte, error) {
 		}
 	}
 
-	// Create an adjusted caching policy for the new subtree.
-	newCachingPolicy := func(layerHeight uint) bool {
-		return cacheReader.GetCachingPolicy()(maxHeight + layerHeight)
-	}
-
-	// Create a subtree with the cache highest layer as its leaves.
-	subtreeWriter := NewWriter(newCachingPolicy, cacheReader.GetLayerFactory())
+	// Create a subtree with adjusted CachingPolicy and LayerFactory.
+	// Use the cache highest layer as its leaves.
+	subtreeWriter := NewWriter(
+		func(layerHeight uint) bool {
+			return cacheReader.GetCachingPolicy()(maxHeight + layerHeight)
+		},
+		func(layerHeight uint) (LayerReadWriter, error) {
+			return cacheReader.GetLayerFactory()(maxHeight + layerHeight)
+		})
 	subtree, err := merkle.NewTreeBuilder().
 		WithHashFunc(cacheReader.GetHashFunc()).
 		WithCacheWriter(subtreeWriter).

--- a/cache/merge_test.go
+++ b/cache/merge_test.go
@@ -1,0 +1,275 @@
+package cache
+
+import (
+	"encoding/binary"
+	"github.com/spacemeshos/merkle-tree"
+	"github.com/spacemeshos/merkle-tree/cache/readwriters"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestMerge(t *testing.T) {
+	r := require.New(t)
+
+	readers := make([]*Reader, 3)
+	readers[0] = &Reader{&cache{layers: make(map[uint]LayerReadWriter)}}
+	readers[1] = &Reader{&cache{layers: make(map[uint]LayerReadWriter)}}
+	readers[2] = &Reader{&cache{layers: make(map[uint]LayerReadWriter)}}
+
+	// Create 9 nodes.
+	nodes := genNodes(9)
+
+	// Split the nodes into 3 layers.
+	splitLayer := make([]LayerReadWriter, 3)
+	splitLayer[0] = &readwriters.SliceReadWriter{}
+	splitLayer[1] = &readwriters.SliceReadWriter{}
+	splitLayer[2] = &readwriters.SliceReadWriter{}
+	_, _ = splitLayer[0].Append(nodes[0])
+	_, _ = splitLayer[0].Append(nodes[1])
+	_, _ = splitLayer[0].Append(nodes[2])
+	_, _ = splitLayer[1].Append(nodes[3])
+	_, _ = splitLayer[1].Append(nodes[4])
+	_, _ = splitLayer[1].Append(nodes[5])
+	_, _ = splitLayer[2].Append(nodes[6])
+	_, _ = splitLayer[2].Append(nodes[7])
+	_, _ = splitLayer[2].Append(nodes[8])
+
+	// Assign the split layer into 3 different readers on height 0.
+	readers[0].cache.layers[0] = splitLayer[0]
+	readers[1].cache.layers[0] = splitLayer[1]
+	readers[2].cache.layers[0] = splitLayer[2]
+
+	var caches []CacheReader
+	for _, reader := range readers {
+		caches = append(caches, CacheReader(reader))
+	}
+	cache, err := Merge(caches)
+	r.NoError(err)
+
+	// Verify the split layers group.
+	layer := cache.GetLayerReader(0)
+	width, err := layer.Width()
+	r.NoError(err)
+	r.Equal(width, uint64(len(nodes)))
+
+	// Iterate over the layer.
+	for _, node := range nodes {
+		val, err := layer.ReadNext()
+		r.NoError(err)
+		r.Equal(val, node)
+	}
+}
+
+func TestMergeFailure1(t *testing.T) {
+	r := require.New(t)
+
+	readers := make([]*Reader, 1)
+	readers[0] = &Reader{&cache{layers: make(map[uint]LayerReadWriter)}}
+
+	var caches []CacheReader
+	for _, reader := range readers {
+		caches = append(caches, CacheReader(reader))
+	}
+	_, err := Merge(caches)
+	r.Equal("number of caches must be at least 2", err.Error())
+}
+
+func TestMergeFailure2(t *testing.T) {
+	r := require.New(t)
+
+	readers := make([]*Reader, 2)
+	readers[0] = &Reader{&cache{layers: make(map[uint]LayerReadWriter)}}
+	readers[1] = &Reader{&cache{layers: make(map[uint]LayerReadWriter)}}
+
+	readers[0].cache.layers[0] = &readwriters.SliceReadWriter{}
+
+	var caches []CacheReader
+	for _, reader := range readers {
+		caches = append(caches, CacheReader(reader))
+	}
+	_, err := Merge(caches)
+	r.Equal("number of layers per height mismatch", err.Error())
+}
+
+func TestMergeAndBuildTopCache(t *testing.T) {
+	r := require.New(t)
+
+	// Create 4 trees.
+	cacheReaders := make([]CacheReader, 4)
+	for i := 0; i < 4; i++ {
+		cacheWriter := NewWriter(MinHeightPolicy(0), MakeSliceReadWriterFactory())
+		tree, err := merkle.NewCachingTree(cacheWriter)
+		r.NoError(err)
+		for i := uint64(0); i < 8; i++ {
+			err := tree.AddLeaf(NewNodeFromUint64(i))
+			r.NoError(err)
+		}
+
+		cacheReader, err := cacheWriter.GetReader()
+		r.NoError(err)
+
+		assertWidth(r, 8, cacheReader.GetLayerReader(0))
+		assertWidth(r, 4, cacheReader.GetLayerReader(1))
+		assertWidth(r, 2, cacheReader.GetLayerReader(2))
+		assertWidth(r, 1, cacheReader.GetLayerReader(3))
+		cacheRoot, err := cacheReader.GetLayerReader(3).ReadNext()
+		r.NoError(err)
+		r.Equal(cacheRoot, tree.Root())
+		err = cacheReader.GetLayerReader(3).Seek(0) // Reset position.
+		r.NoError(err)
+
+		cacheReaders[i] = cacheReader
+	}
+
+	// Merge caches, and verify that the upper subtree is missing.
+	cacheReader, err := Merge(cacheReaders)
+	r.NoError(err)
+	assertWidth(r, 32, cacheReader.GetLayerReader(0))
+	assertWidth(r, 16, cacheReader.GetLayerReader(1))
+	assertWidth(r, 8, cacheReader.GetLayerReader(2))
+	assertWidth(r, 4, cacheReader.GetLayerReader(3))
+	r.Nil(cacheReader.GetLayerReader(4))
+	r.Nil(cacheReader.GetLayerReader(5))
+
+	// Create the upper subtree.
+	cacheReader, root, err := BuildTop(cacheReader)
+	r.NoError(err)
+	assertWidth(r, 32, cacheReader.GetLayerReader(0))
+	assertWidth(r, 16, cacheReader.GetLayerReader(1))
+	assertWidth(r, 8, cacheReader.GetLayerReader(2))
+	assertWidth(r, 4, cacheReader.GetLayerReader(3))
+	assertWidth(r, 2, cacheReader.GetLayerReader(4))
+	assertWidth(r, 1, cacheReader.GetLayerReader(5))
+
+	// Compare the cache root with the root received from BuildTop.
+	cacheRoot, err := cacheReader.GetLayerReader(5).ReadNext()
+	r.NoError(err)
+	r.Equal(cacheRoot, root)
+	err = cacheReader.GetLayerReader(5).Seek(0) // Reset position.
+	r.NoError(err)
+}
+
+func TestMergeAndBuildTop(t *testing.T) {
+	r := require.New(t)
+
+	// Create 32 nodes.
+	nodes := genNodes(32)
+
+	// Add the nodes as leaves to one tree and save its root.
+	cacheWriter := NewWriter(MinHeightPolicy(0), MakeSliceReadWriterFactory())
+	tree, err := merkle.NewCachingTree(cacheWriter)
+	r.NoError(err)
+	for i := 0; i < len(nodes); i++ {
+		err := tree.AddLeaf(NewNodeFromUint64(uint64(i)))
+		r.NoError(err)
+	}
+	treeRoot := tree.Root()
+
+	// Add the nodes as leaves to 4 separate trees.
+	cacheWriters := make([]CacheWriter, 4)
+	cacheReaders := make([]CacheReader, 4)
+	trees := make([]*merkle.Tree, 4)
+	for i := 0; i < 4; i++ {
+		cacheWriter := NewWriter(MinHeightPolicy(0), MakeSliceReadWriterFactory())
+		tree, err := merkle.NewCachingTree(cacheWriter)
+		r.NoError(err)
+
+		cacheWriters[i] = cacheWriter
+		trees[i] = tree
+	}
+	for i := 0; i < len(nodes); i++ {
+		err := trees[i/8].AddLeaf(NewNodeFromUint64(uint64(i)))
+		r.NoError(err)
+	}
+	for i := 0; i < 4; i++ {
+		reader, err := cacheWriters[i].GetReader()
+		r.NoError(err)
+		cacheReaders[i] = reader
+	}
+
+	// Merge caches.
+	cacheReader, err := Merge(cacheReaders)
+	r.NoError(err)
+	r.NotNil(cacheReader)
+
+	// Create the upper subtree.
+	cacheReader, mergeRoot, err := BuildTop(cacheReader)
+	r.NoError(err)
+	r.NotNil(cacheReader)
+
+	// Verify that the 4 trees merge root is the same as the main tree root.
+	r.Equal(mergeRoot, treeRoot)
+}
+
+// -- FAILING --
+func TestMergeAndBuildTopUnbalanced(t *testing.T) {
+	r := require.New(t)
+
+	// Create 29 nodes.
+	nodes := genNodes(29)
+
+	// Add the nodes as leaves to one tree and save its root.
+	cacheWriter := NewWriter(MinHeightPolicy(0), MakeSliceReadWriterFactory())
+	tree, err := merkle.NewCachingTree(cacheWriter)
+	r.NoError(err)
+	for i := 0; i < len(nodes); i++ {
+		err := tree.AddLeaf(NewNodeFromUint64(uint64(i)))
+		r.NoError(err)
+	}
+	treeRoot := tree.Root()
+
+	// Add the nodes as leaves to 4 separate trees.
+	cacheWriters := make([]CacheWriter, 4)
+	cacheReaders := make([]CacheReader, 4)
+	trees := make([]*merkle.Tree, 4)
+	for i := 0; i < 4; i++ {
+		cacheWriter := NewWriter(MinHeightPolicy(0), MakeSliceReadWriterFactory())
+		tree, err := merkle.NewCachingTree(cacheWriter)
+		r.NoError(err)
+
+		cacheWriters[i] = cacheWriter
+		trees[i] = tree
+	}
+	for i := 0; i < len(nodes); i++ {
+		err := trees[i/8].AddLeaf(NewNodeFromUint64(uint64(i)))
+		r.NoError(err)
+	}
+	for i := 0; i < 4; i++ {
+		reader, err := cacheWriters[i].GetReader()
+		r.NoError(err)
+		cacheReaders[i] = reader
+	}
+
+	// Merge caches.
+	cacheReader, err := Merge(cacheReaders)
+	r.NoError(err)
+	r.NotNil(cacheReader)
+
+	// Create the upper subtree.
+	cacheReader, mergeRoot, err := BuildTop(cacheReader)
+	r.NoError(err)
+	r.NotNil(cacheReader)
+
+	// Verify that the 4 trees merge root is the same as the main tree root.
+	r.Equal(mergeRoot, treeRoot)
+}
+
+func genNodes(num int) [][]byte {
+	nodes := make([][]byte, num)
+	for i := 0; i < num; i++ {
+		nodes[i] = NewNodeFromUint64(uint64(i))
+	}
+	return nodes
+}
+
+func NewNodeFromUint64(i uint64) []byte {
+	b := make([]byte, NodeSize)
+	binary.LittleEndian.PutUint64(b, i)
+	return b
+}
+
+func assertWidth(r *require.Assertions, expectedWidth int, layerReader LayerReader) {
+	width, err := layerReader.Width()
+	r.NoError(err)
+	r.Equal(uint64(expectedWidth), width)
+}

--- a/cache/readwriters/file.go
+++ b/cache/readwriters/file.go
@@ -3,6 +3,7 @@ package readwriters
 import (
 	"bufio"
 	"fmt"
+	"github.com/spacemeshos/merkle-tree/shared"
 	"io"
 	"os"
 )
@@ -24,6 +25,9 @@ type FileReadWriter struct {
 	f *os.File
 	b *bufio.ReadWriter
 }
+
+// A compile time check to ensure that FileReadWriter fully implements LayerReadWriter.
+var _ shared.LayerReadWriter = (*FileReadWriter)(nil)
 
 func (rw *FileReadWriter) Seek(index uint64) error {
 	_, err := rw.f.Seek(int64(index*NodeSize), io.SeekStart)

--- a/cache/readwriters/slice.go
+++ b/cache/readwriters/slice.go
@@ -1,15 +1,19 @@
 package readwriters
 
 import (
+	"github.com/spacemeshos/merkle-tree/shared"
 	"io"
 )
 
-const NodeSize = 32
+const NodeSize = shared.NodeSize
 
 type SliceReadWriter struct {
 	slice    [][]byte
 	position uint64
 }
+
+// A compile time check to ensure that SliceReadWriter fully implements LayerReadWriter.
+var _ shared.LayerReadWriter = (*SliceReadWriter)(nil)
 
 func (s *SliceReadWriter) Width() (uint64, error) {
 	return uint64(len(s.slice)), nil

--- a/iterators.go
+++ b/iterators.go
@@ -7,9 +7,9 @@ import (
 
 var noMoreItems = errors.New("no more items")
 
-type set map[uint64]bool
+type Set map[uint64]bool
 
-func (s set) asSortedSlice() []uint64 {
+func (s Set) AsSortedSlice() []uint64 {
 	var ret []uint64
 	for key, value := range s {
 		if value {
@@ -20,8 +20,8 @@ func (s set) asSortedSlice() []uint64 {
 	return ret
 }
 
-func setOf(members ...uint64) set {
-	ret := make(set)
+func SetOf(members ...uint64) Set {
+	ret := make(Set)
 	for _, member := range members {
 		ret[member] = true
 	}
@@ -32,22 +32,22 @@ type positionsIterator struct {
 	s []uint64
 }
 
-func newPositionsIterator(positions set) *positionsIterator {
-	s := positions.asSortedSlice()
+func NewPositionsIterator(positions Set) *positionsIterator {
+	s := positions.AsSortedSlice()
 	return &positionsIterator{s: s}
 }
 
-func (it *positionsIterator) peek() (pos position, found bool) {
+func (it *positionsIterator) peek() (pos Position, found bool) {
 	if len(it.s) == 0 {
-		return position{}, false
+		return Position{}, false
 	}
 	index := it.s[0]
-	return position{index: index}, true
+	return Position{Index: index}, true
 }
 
 // batchPop returns the indices of all positions up to endIndex.
-func (it *positionsIterator) batchPop(endIndex uint64) set {
-	res := make(set)
+func (it *positionsIterator) batchPop(endIndex uint64) Set {
+	res := make(Set)
 	for len(it.s) > 0 && it.s[0] < endIndex {
 		res[it.s[0]] = true
 		it.s = it.s[1:]
@@ -68,27 +68,27 @@ func (it *proofIterator) next() ([]byte, error) {
 	return n, nil
 }
 
-type leafIterator struct {
+type LeafIterator struct {
 	indices []uint64
 	leaves  [][]byte
 }
 
-// leafIterator.next() returns the leaf index and value
-func (it *leafIterator) next() (position, []byte, error) {
+// LeafIterator.next() returns the leaf index and value
+func (it *LeafIterator) next() (Position, []byte, error) {
 	if len(it.indices) == 0 {
-		return position{}, nil, noMoreItems
+		return Position{}, nil, noMoreItems
 	}
 	idx := it.indices[0]
 	leaf := it.leaves[0]
 	it.indices = it.indices[1:]
 	it.leaves = it.leaves[1:]
-	return position{index: idx}, leaf, nil
+	return Position{Index: idx}, leaf, nil
 }
 
-// leafIterator.peek() returns the leaf index but doesn't move the iterator to this leaf as next would do
-func (it *leafIterator) peek() (position, []byte, error) {
+// LeafIterator.peek() returns the leaf index but doesn't move the iterator to this leaf as next would do
+func (it *LeafIterator) peek() (Position, []byte, error) {
 	if len(it.indices) == 0 {
-		return position{}, nil, noMoreItems
+		return Position{}, nil, noMoreItems
 	}
-	return position{index: it.indices[0]}, it.leaves[0], nil
+	return Position{Index: it.indices[0]}, it.leaves[0], nil
 }

--- a/merkle_test.go
+++ b/merkle_test.go
@@ -196,6 +196,7 @@ func TestNewTreeUnbalancedProof(t *testing.T) {
 }
 
 func assertWidth(r *require.Assertions, expectedWidth int, layerReader cache.LayerReader) {
+	r.NotNil(layerReader)
 	width, err := layerReader.Width()
 	r.NoError(err)
 	r.Equal(uint64(expectedWidth), width)

--- a/merkle_test.go
+++ b/merkle_test.go
@@ -1,13 +1,38 @@
-package merkle
+package merkle_test
 
 import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"github.com/spacemeshos/merkle-tree"
 	"github.com/spacemeshos/merkle-tree/cache"
 	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+)
+
+var (
+	NewTree                                 = merkle.NewTree
+	NewTreeBuilder                          = merkle.NewTreeBuilder
+	NewProvingTree                          = merkle.NewProvingTree
+	NewCachingTree                          = merkle.NewCachingTree
+	GenerateProof                           = merkle.GenerateProof
+	ValidatePartialTree                     = merkle.ValidatePartialTree
+	ValidatePartialTreeWithParkingSnapshots = merkle.ValidatePartialTreeWithParkingSnapshots
+	GetSha256Parent                         = merkle.GetSha256Parent
+	GetNode                                 = merkle.GetNode
+	setOf                                   = merkle.SetOf
+	newSparseBoolStack                      = merkle.NewSparseBoolStack
+	emptyNode                               = merkle.EmptyNode
+	NodeSize                                = merkle.NodeSize
+)
+
+type (
+	set          = merkle.Set
+	position     = merkle.Position
+	validator    = merkle.Validator
+	leafIterator = merkle.LeafIterator
+	CacheReader  = cache.CacheReader
 )
 
 /*
@@ -398,7 +423,7 @@ func TestEmptyNode(t *testing.T) {
 	r := require.New(t)
 
 	r.True(emptyNode.IsEmpty())
-	r.False(emptyNode.onProvenPath)
+	r.False(emptyNode.OnProvenPath)
 }
 
 func TestTree_GetParkedNodes(t *testing.T) {
@@ -477,8 +502,8 @@ func ExampleTree() {
 
 	// We now have access to a sorted list of proven leaves, the values of those leaves and the Merkle proof for them:
 	fmt.Println(sortedProvenLeafIndices) // 0 4 7
-	fmt.Println(nodes(provenLeaves)) // 0000 0400 0700
-	fmt.Println(nodes(proof)) // 0100 0094 0500 0600
+	fmt.Println(nodes(provenLeaves))     // 0000 0400 0700
+	fmt.Println(nodes(proof))            // 0100 0094 0500 0600
 
 	// We can validate these values using ValidatePartialTree:
 	valid, err := ValidatePartialTree(sortedProvenLeafIndices, provenLeaves, proof, tree.Root(), GetSha256Parent)

--- a/position.go
+++ b/position.go
@@ -2,57 +2,57 @@ package merkle
 
 import "fmt"
 
-type position struct {
-	index  uint64
-	height uint
+type Position struct {
+	Index  uint64
+	Height uint
 }
 
-func (p position) String() string {
-	return fmt.Sprintf("<h: %d i: %b>", p.height, p.index)
+func (p Position) String() string {
+	return fmt.Sprintf("<h: %d i: %b>", p.Height, p.Index)
 }
 
-func (p position) sibling() position {
-	return position{
-		index:  p.index ^ 1,
-		height: p.height,
+func (p Position) sibling() Position {
+	return Position{
+		Index:  p.Index ^ 1,
+		Height: p.Height,
 	}
 }
 
-func (p position) isAncestorOf(other position) bool {
-	if p.height < other.height {
+func (p Position) isAncestorOf(other Position) bool {
+	if p.Height < other.Height {
 		return false
 	}
-	return p.index == (other.index >> (p.height - other.height))
+	return p.Index == (other.Index >> (p.Height - other.Height))
 }
 
-func (p position) isRightSibling() bool {
-	return p.index%2 == 1
+func (p Position) isRightSibling() bool {
+	return p.Index%2 == 1
 }
 
-func (p position) parent() position {
-	return position{
-		index:  p.index >> 1,
-		height: p.height + 1,
+func (p Position) parent() Position {
+	return Position{
+		Index:  p.Index >> 1,
+		Height: p.Height + 1,
 	}
 }
 
-func (p position) leftChild() position {
-	return position{
-		index:  p.index << 1,
-		height: p.height - 1,
+func (p Position) leftChild() Position {
+	return Position{
+		Index:  p.Index << 1,
+		Height: p.Height - 1,
 	}
 }
 
 type positionsStack struct {
-	positions []position
+	positions []Position
 }
 
-func (s *positionsStack) Push(v position) {
+func (s *positionsStack) Push(v Position) {
 	s.positions = append(s.positions, v)
 }
 
 // Check the top of the stack for equality and pop the element if it's equal.
-func (s *positionsStack) PopIfEqual(p position) bool {
+func (s *positionsStack) PopIfEqual(p Position) bool {
 	l := len(s.positions)
 	if l == 0 {
 		return false

--- a/position_test.go
+++ b/position_test.go
@@ -6,14 +6,14 @@ import (
 )
 
 func TestPosition_isAncestorOf(t *testing.T) {
-	lower := position{
-		index:  0,
-		height: 0,
+	lower := Position{
+		Index:  0,
+		Height: 0,
 	}
 
-	higher := position{
-		index:  0,
-		height: 1,
+	higher := Position{
+		Index:  0,
+		Height: 1,
 	}
 
 	isAncestor := lower.isAncestorOf(higher)

--- a/proving_test.go
+++ b/proving_test.go
@@ -1,4 +1,4 @@
-package merkle
+package merkle_test
 
 import (
 	"encoding/hex"
@@ -57,7 +57,7 @@ func TestGenerateProof(t *testing.T) {
 	r.EqualValues(expectedProof, proof)
 
 	var expectedLeaves nodes
-	for _, i := range leavesToProve.asSortedSlice() {
+	for _, i := range leavesToProve.AsSortedSlice() {
 		expectedLeaves = append(expectedLeaves, NewNodeFromUint64(i))
 	}
 	r.EqualValues(expectedLeaves, leaves)
@@ -105,7 +105,7 @@ func BenchmarkGenerateProof(b *testing.B) {
 	r.EqualValues(expectedProof, proof)
 
 	var expectedLeaves nodes
-	for _, i := range leavesToProve.asSortedSlice() {
+	for _, i := range leavesToProve.AsSortedSlice() {
 		expectedLeaves = append(expectedLeaves, NewNodeFromUint64(i))
 	}
 	r.EqualValues(expectedLeaves, leaves)
@@ -153,7 +153,7 @@ func TestGenerateProofWithRoot(t *testing.T) {
 	r.EqualValues(expectedProof, proof)
 
 	var expectedLeaves nodes
-	for _, i := range leavesToProve.asSortedSlice() {
+	for _, i := range leavesToProve.AsSortedSlice() {
 		expectedLeaves = append(expectedLeaves, NewNodeFromUint64(i))
 	}
 	r.EqualValues(expectedLeaves, leaves)
@@ -189,7 +189,7 @@ func TestGenerateProofWithoutCache(t *testing.T) {
 	r.EqualValues(expectedProof, proof)
 
 	var expectedLeaves nodes
-	for _, i := range leavesToProve.asSortedSlice() {
+	for _, i := range leavesToProve.AsSortedSlice() {
 		expectedLeaves = append(expectedLeaves, NewNodeFromUint64(i))
 	}
 	r.EqualValues(expectedLeaves, leaves)
@@ -228,7 +228,7 @@ func TestGenerateProofWithSingleLayerCache(t *testing.T) {
 	r.EqualValues(expectedProof, proof)
 
 	var expectedLeaves nodes
-	for _, i := range leavesToProve.asSortedSlice() {
+	for _, i := range leavesToProve.AsSortedSlice() {
 		expectedLeaves = append(expectedLeaves, NewNodeFromUint64(i))
 	}
 	r.EqualValues(expectedLeaves, leaves)
@@ -267,7 +267,7 @@ func TestGenerateProofWithSingleLayerCache2(t *testing.T) {
 	r.EqualValues(expectedProof, proof)
 
 	var expectedLeaves nodes
-	for _, i := range leavesToProve.asSortedSlice() {
+	for _, i := range leavesToProve.AsSortedSlice() {
 		expectedLeaves = append(expectedLeaves, NewNodeFromUint64(i))
 	}
 	r.EqualValues(expectedLeaves, leaves)
@@ -337,7 +337,7 @@ func TestGenerateProofUnbalanced(t *testing.T) {
 	r.EqualValues(expectedProof, proof)
 
 	var expectedLeaves nodes
-	for _, i := range leavesToProve.asSortedSlice() {
+	for _, i := range leavesToProve.AsSortedSlice() {
 		expectedLeaves = append(expectedLeaves, NewNodeFromUint64(i))
 	}
 	r.EqualValues(expectedLeaves, leaves)
@@ -375,7 +375,7 @@ func TestGenerateProofUnbalanced2(t *testing.T) {
 	r.EqualValues(expectedProof, proof)
 
 	var expectedLeaves nodes
-	for _, i := range leavesToProve.asSortedSlice() {
+	for _, i := range leavesToProve.AsSortedSlice() {
 		expectedLeaves = append(expectedLeaves, NewNodeFromUint64(i))
 	}
 	r.EqualValues(expectedLeaves, leaves)
@@ -413,7 +413,7 @@ func TestGenerateProofUnbalanced3(t *testing.T) {
 	r.EqualValues(expectedProof, proof)
 
 	var expectedLeaves nodes
-	for _, i := range leavesToProve.asSortedSlice() {
+	for _, i := range leavesToProve.AsSortedSlice() {
 		expectedLeaves = append(expectedLeaves, NewNodeFromUint64(i))
 	}
 	r.EqualValues(expectedLeaves, leaves)
@@ -434,7 +434,8 @@ var someError = errors.New("some error")
 
 type seekErrorReader struct{}
 
-var _ cache.LayerReadWriter = &seekErrorReader{}
+// A compile time check to ensure that seekErrorReader fully implements LayerReadWriter.
+var _ cache.LayerReadWriter = (*seekErrorReader)(nil)
 
 func (seekErrorReader) Seek(index uint64) error            { return someError }
 func (seekErrorReader) ReadNext() ([]byte, error)          { panic("implement me") }
@@ -444,7 +445,8 @@ func (seekErrorReader) Flush() error                       { return nil }
 
 type readErrorReader struct{}
 
-var _ cache.LayerReadWriter = &readErrorReader{}
+// A compile time check to ensure that readErrorReader fully implements LayerReadWriter.
+var _ cache.LayerReadWriter = (*readErrorReader)(nil)
 
 func (readErrorReader) Seek(index uint64) error            { return nil }
 func (readErrorReader) ReadNext() ([]byte, error)          { return nil, someError }
@@ -454,7 +456,8 @@ func (readErrorReader) Flush() error                       { return nil }
 
 type seekEOFReader struct{}
 
-var _ cache.LayerReadWriter = &seekEOFReader{}
+// A compile time check to ensure that seekEOFReader fully implements LayerReadWriter.
+var _ cache.LayerReadWriter = (*seekEOFReader)(nil)
 
 func (seekEOFReader) Seek(index uint64) error            { return io.EOF }
 func (seekEOFReader) ReadNext() ([]byte, error)          { panic("implement me") }
@@ -464,7 +467,8 @@ func (seekEOFReader) Flush() error                       { return nil }
 
 type widthReader struct{ width uint64 }
 
-var _ cache.LayerReadWriter = &widthReader{}
+// A compile time check to ensure that widthReader fully implements LayerReadWriter.
+var _ cache.LayerReadWriter = (*widthReader)(nil)
 
 func (r widthReader) Seek(index uint64) error            { return nil }
 func (r widthReader) ReadNext() ([]byte, error)          { return nil, someError }
@@ -485,7 +489,7 @@ func TestGetNode(t *testing.T) {
 	node, err := GetNode(cacheReader, nodePos)
 
 	r.Error(err)
-	r.Equal("while seeking to position <h: 0 i: 0> in cache: some error", err.Error())
+	r.Equal("while seeking to Position <h: 0 i: 0> in cache: some error", err.Error())
 	r.Nil(node)
 
 }
@@ -513,11 +517,11 @@ func TestGetNode3(t *testing.T) {
 
 	cacheReader, err := cacheWriter.GetReader()
 	r.NoError(err)
-	nodePos := position{height: 1}
+	nodePos := position{Height: 1}
 	node, err := GetNode(cacheReader, nodePos)
 
 	r.Error(err)
-	r.Equal("while seeking to position <h: 0 i: 0> in cache: some error", err.Error())
+	r.Equal("while seeking to Position <h: 0 i: 0> in cache: some error", err.Error())
 	r.Nil(node)
 }
 
@@ -530,11 +534,11 @@ func TestGetNode4(t *testing.T) {
 
 	cacheReader, err := cacheWriter.GetReader()
 	r.NoError(err)
-	nodePos := position{height: 2}
+	nodePos := position{Height: 2}
 	node, err := GetNode(cacheReader, nodePos)
 
 	r.Error(err)
-	r.Equal("while calculating ephemeral node at position <h: 1 i: 1>: while seeking to position <h: 0 i: 10> in cache: some error", err.Error())
+	r.Equal("while calculating ephemeral node at Position <h: 1 i: 1>: while seeking to Position <h: 0 i: 10> in cache: some error", err.Error())
 	r.Nil(node)
 }
 
@@ -546,7 +550,7 @@ func TestGetNode5(t *testing.T) {
 
 	cacheReader, err := cacheWriter.GetReader()
 	r.NoError(err)
-	nodePos := position{height: 1}
+	nodePos := position{Height: 1}
 	node, err := GetNode(cacheReader, nodePos)
 
 	r.Error(err)

--- a/shared/consts.go
+++ b/shared/consts.go
@@ -1,0 +1,5 @@
+package shared
+
+const (
+	NodeSize = 32
+)

--- a/shared/types.go
+++ b/shared/types.go
@@ -1,0 +1,34 @@
+package shared
+
+type HashFunc func(lChild, rChild []byte) []byte
+
+// LayerReadWriter is a combined reader-writer. Note that the Seek() method only belongs to the LayerReader interface
+// and does not affect the LayerWriter.
+type LayerReadWriter interface {
+	LayerReader
+	LayerWriter
+}
+
+type LayerReader interface {
+	Seek(index uint64) error
+	ReadNext() ([]byte, error)
+	Width() (uint64, error)
+}
+
+type LayerWriter interface {
+	Append(p []byte) (n int, err error)
+	Flush() error
+}
+
+type CacheWriter interface {
+	SetLayer(layerHeight uint, rw LayerReadWriter)
+	GetLayerWriter(layerHeight uint) (LayerWriter, error)
+	SetHash(hashFunc HashFunc)
+	GetReader() (CacheReader, error)
+}
+
+type CacheReader interface {
+	Layers() map[uint]LayerReadWriter
+	GetLayerReader(layerHeight uint) LayerReader
+	GetHashFunc() HashFunc
+}

--- a/shared/types.go
+++ b/shared/types.go
@@ -31,4 +31,10 @@ type CacheReader interface {
 	Layers() map[uint]LayerReadWriter
 	GetLayerReader(layerHeight uint) LayerReader
 	GetHashFunc() HashFunc
+	GetLayerFactory() LayerFactory
+	GetCachingPolicy() CachingPolicy
 }
+
+type CachingPolicy func(layerHeight uint) (shouldCacheLayer bool)
+
+type LayerFactory func(layerHeight uint) (LayerReadWriter, error)

--- a/shared/utils.go
+++ b/shared/utils.go
@@ -1,0 +1,7 @@
+package shared
+
+import "math"
+
+func RootHeightFromWidth(width uint64) uint {
+	return uint(math.Ceil(math.Log2(float64(width))))
+}

--- a/validation_test.go
+++ b/validation_test.go
@@ -1,4 +1,4 @@
-package merkle
+package merkle_test
 
 import (
 	"fmt"
@@ -300,13 +300,13 @@ func TestValidatePartialTreeErrors(t *testing.T) {
 func TestValidator_calcRoot(t *testing.T) {
 	r := require.New(t)
 	v := validator{
-		leaves:         &leafIterator{},
-		proofNodes:     nil,
-		hash:           nil,
-		storeSnapshots: false,
+		Leaves:         &leafIterator{},
+		ProofNodes:     nil,
+		Hash:           nil,
+		StoreSnapshots: false,
 	}
 
-	root, _, err := v.calcRoot(0)
+	root, _, err := v.CalcRoot(0)
 
 	r.Error(err)
 	r.Equal("no more items", err.Error())


### PR DESCRIPTION
* Adding trees cache merging support (`cache.Merge` and `cache.BuildTop` functions).
* Reversed the dependency between `cache` and `merkle` packages, so that `cache` will consume `merkle`. This was done because in `cache.BuildTop` a new tree is being built. It required to turn `merkle_test.go` to black-box testing, and so some types/fields in `merkle` package had to turn public. Other solutions were applicable, but we could improve that in a follow-up PR. 
* `TestMergeAndBuildTopUnbalanced` test is currently failing. @noamnelke please give a look on that before i'll fix it, to verify that we want to support this scenario. 

Added #9 and #10 issues for follow-up PRs. 