### PR TITLE
Add reader/writer close method

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -18,6 +18,7 @@ func (r widthReader) ReadNext() ([]byte, error)          { return nil, someError
 func (r widthReader) Width() (uint64, error)             { return r.width, nil }
 func (r widthReader) Append(p []byte) (n int, err error) { panic("implement me") }
 func (r widthReader) Flush() error                       { return nil }
+func (r widthReader) Close() error                       { return nil }
 
 func TestCache_ValidateStructure(t *testing.T) {
 	r := require.New(t)

--- a/cache/group.go
+++ b/cache/group.go
@@ -96,3 +96,13 @@ func (g *GroupLayerReadWriter) Width() (uint64, error) {
 func (g *GroupLayerReadWriter) Append(p []byte) (n int, err error) { return 0, nil }
 
 func (g *GroupLayerReadWriter) Flush() error { return nil }
+
+func (g *GroupLayerReadWriter) Close() error {
+	for _, chunk := range g.chunks {
+		err := chunk.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cache/group_test.go
+++ b/cache/group_test.go
@@ -78,6 +78,9 @@ func TestGroupLayers(t *testing.T) {
 	}
 	err = layer.Seek(0)
 	r.NoError(err)
+
+	err = layer.Close()
+	r.NoError(err)
 }
 
 func TestGroupLayersWithShorterLastLayer(t *testing.T) {

--- a/cache/readwriters/file.go
+++ b/cache/readwriters/file.go
@@ -71,3 +71,19 @@ func (rw *FileReadWriter) Flush() error {
 	}
 	return nil
 }
+
+func (rw *FileReadWriter) Close() error {
+	err := rw.b.Flush()
+	if err != nil {
+		return fmt.Errorf("failed to flush disk writer: %v", err)
+	}
+	rw.b = nil
+
+	err = rw.f.Close()
+	if err != nil {
+		return err
+	}
+	rw.f = nil
+
+	return nil
+}

--- a/cache/readwriters/file_test.go
+++ b/cache/readwriters/file_test.go
@@ -48,6 +48,9 @@ func TestFileReadWriter(t *testing.T) {
 	next, err = readWriter.ReadNext()
 	r.NoError(err)
 	r.Equal(string(makeLabel("else")), string(next))
+
+	err = readWriter.Close()
+	r.NoError(err)
 }
 
 func makeLabel(s string) []byte {

--- a/cache/readwriters/slice.go
+++ b/cache/readwriters/slice.go
@@ -45,3 +45,7 @@ func (s *SliceReadWriter) Append(p []byte) (n int, err error) {
 func (s *SliceReadWriter) Flush() error {
 	return nil
 }
+
+func (s *SliceReadWriter) Close() error {
+	return nil
+}

--- a/proving_test.go
+++ b/proving_test.go
@@ -442,6 +442,7 @@ func (seekErrorReader) ReadNext() ([]byte, error)          { panic("implement me
 func (seekErrorReader) Width() (uint64, error)             { return 3, nil }
 func (seekErrorReader) Append(p []byte) (n int, err error) { panic("implement me") }
 func (seekErrorReader) Flush() error                       { return nil }
+func (seekErrorReader) Close() error                       { return nil }
 
 type readErrorReader struct{}
 
@@ -453,6 +454,7 @@ func (readErrorReader) ReadNext() ([]byte, error)          { return nil, someErr
 func (readErrorReader) Width() (uint64, error)             { return 8, nil }
 func (readErrorReader) Append(p []byte) (n int, err error) { panic("implement me") }
 func (readErrorReader) Flush() error                       { return nil }
+func (readErrorReader) Close() error                       { return nil }
 
 type seekEOFReader struct{}
 
@@ -464,6 +466,7 @@ func (seekEOFReader) ReadNext() ([]byte, error)          { panic("implement me")
 func (seekEOFReader) Width() (uint64, error)             { return 1, nil }
 func (seekEOFReader) Append(p []byte) (n int, err error) { panic("implement me") }
 func (seekEOFReader) Flush() error                       { return nil }
+func (seekEOFReader) Close() error                       { return nil }
 
 type widthReader struct{ width uint64 }
 
@@ -475,6 +478,7 @@ func (r widthReader) ReadNext() ([]byte, error)          { return nil, someError
 func (r widthReader) Width() (uint64, error)             { return r.width, nil }
 func (r widthReader) Append(p []byte) (n int, err error) { panic("implement me") }
 func (r widthReader) Flush() error                       { return nil }
+func (r widthReader) Close() error                       { return nil }
 
 func TestGetNode(t *testing.T) {
 	r := require.New(t)

--- a/shared/types.go
+++ b/shared/types.go
@@ -5,19 +5,25 @@ type HashFunc func(lChild, rChild []byte) []byte
 // LayerReadWriter is a combined reader-writer. Note that the Seek() method only belongs to the LayerReader interface
 // and does not affect the LayerWriter.
 type LayerReadWriter interface {
-	LayerReader
-	LayerWriter
+	Seek(index uint64) error
+	ReadNext() ([]byte, error)
+	Width() (uint64, error)
+	Append(p []byte) (n int, err error)
+	Flush() error
+	Close() error
 }
 
 type LayerReader interface {
 	Seek(index uint64) error
 	ReadNext() ([]byte, error)
 	Width() (uint64, error)
+	Close() error
 }
 
 type LayerWriter interface {
 	Append(p []byte) (n int, err error)
 	Flush() error
+	Close() error
 }
 
 type CacheWriter interface {


### PR DESCRIPTION
Add reader/writer `close` method, which is necessary when the layer is backed by a file.