### PR TITLE
Set parked nodes support

### DIFF
--- a/merkle.go
+++ b/merkle.go
@@ -226,6 +226,25 @@ func (t *Tree) GetParkedNodes() [][]byte {
 	return ret
 }
 
+func (t *Tree) SetParkedNodes(nodes [][]byte) error {
+	layer := t.baseLayer
+	for i := 0; i < len(nodes); i++ {
+		if nodes[i] != nil {
+			layer.parking.value = nodes[i]
+		}
+
+		if i < len(nodes)-1 {
+			err := layer.ensureNextLayerExists(t.cacheWriter)
+			if err != nil {
+				return err
+			}
+			layer = layer.next
+		}
+	}
+
+	return nil
+}
+
 // calcEphemeralParent calculates the parent using the layer parking and ephemeralNode. When one of those is missing it
 // uses PaddingValue to pad. It returns the actual nodes used along with the parent.
 func (t *Tree) calcEphemeralParent(parking, ephemeralNode node) (parent, lChild, rChild node) {

--- a/merkle_test.go
+++ b/merkle_test.go
@@ -454,6 +454,31 @@ func TestTree_GetParkedNodes(t *testing.T) {
 		tree.GetParkedNodes())
 }
 
+func TestTree_SetParkedNodes(t *testing.T) {
+	r := require.New(t)
+
+	tree, err := NewTreeBuilder().Build()
+	r.NoError(err)
+	r.NoError(tree.SetParkedNodes([][]byte{{0}}))
+	r.NoError(tree.AddLeaf([]byte{1}))
+	parkedNodes := [][]byte{nil, decode(r, "b413f47d13ee2fe6c845b2ee141af81de858df4ec549a58b7970bb96645bc8d2")}
+	r.EqualValues(parkedNodes, tree.GetParkedNodes())
+
+	tree, err = NewTreeBuilder().Build()
+	r.NoError(err)
+	r.NoError(tree.SetParkedNodes(parkedNodes))
+	r.NoError(tree.AddLeaf([]byte{2}))
+	parkedNodes = [][]byte{{2}, decode(r, "b413f47d13ee2fe6c845b2ee141af81de858df4ec549a58b7970bb96645bc8d2")}
+	r.EqualValues(parkedNodes, tree.GetParkedNodes())
+
+	tree, err = NewTreeBuilder().Build()
+	r.NoError(err)
+	r.NoError(tree.SetParkedNodes(parkedNodes))
+	r.NoError(tree.AddLeaf([]byte{3}))
+	parkedNodes = [][]byte{nil, nil, decode(r, "7699a4fdd6b8b6908a344f73b8f05c8e1400f7253f544602c442ff5c65504b24")}
+	r.EqualValues(parkedNodes, tree.GetParkedNodes())
+}
+
 func decode(r *require.Assertions, hexString string) []byte {
 	hash, err := hex.DecodeString(hexString)
 	r.NoError(err)


### PR DESCRIPTION
Add `SetParkedNodes` method to to the tree API. 

A requirement for https://github.com/spacemeshos/go-spacemesh/issues/879.