### PR TITLE
FileReadWriter to append file

### DIFF
--- a/cache/readwriters/file.go
+++ b/cache/readwriters/file.go
@@ -11,7 +11,7 @@ import (
 const OwnerReadWrite = 0600
 
 func NewFileReadWriter(filename string) (*FileReadWriter, error) {
-	f, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, OwnerReadWrite)
+	f, err := os.OpenFile(filename, os.O_RDWR|os.O_APPEND|os.O_CREATE, OwnerReadWrite)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file for disk read-writer: %v", err)
 	}


### PR DESCRIPTION
Change `FileReadWriter` to append to an existing file instead of overriding it.

A requirement for spacemeshos/go-spacemesh#879.