### PR TITLE
Add Close method to cache writer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,13 @@
 name: CI
 
 env:
-  go-version: "1.18"
+  go-version: "1.19"
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the develop branch
 on:
-  push:
-    branches: [develop]
   pull_request:
+  push:
     branches: [develop]
 
 jobs:

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -60,6 +60,12 @@ func (c *Writer) SetHash(hashFunc HashFunc) {
 	c.hash = hashFunc
 }
 
+func (c *Writer) Close() {
+	for _, layer := range c.layers {
+		layer.Close()
+	}
+}
+
 // GetReader returns a cache reader that can be passed into GenerateProof. It first flushes the layer writers to support
 // layer writers that have internal buffers that may not be reflected in the reader until flushed. After flushing, this
 // method validates the structure of the cache, including that a base layer is cached.

--- a/cache/cachingpolicies_test.go
+++ b/cache/cachingpolicies_test.go
@@ -3,8 +3,9 @@ package cache
 import (
 	"testing"
 
-	"github.com/spacemeshos/merkle-tree/cache/readwriters"
 	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/merkle-tree/cache/readwriters"
 )
 
 func TestMakeMemoryReadWriterFactory(t *testing.T) {

--- a/merkle.go
+++ b/merkle.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/minio/sha256-simd"
+
 	"github.com/spacemeshos/merkle-tree/shared"
 )
 

--- a/merkle_test.go
+++ b/merkle_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/spacemeshos/merkle-tree"
 	"github.com/spacemeshos/merkle-tree/cache"
-	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/proving_test.go
+++ b/proving_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spacemeshos/merkle-tree/cache"
 	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/merkle-tree/cache"
 )
 
 /*

--- a/validation_test.go
+++ b/validation_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/spacemeshos/merkle-tree/cache"
 	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/merkle-tree/cache"
 )
 
 func TestValidatePartialTree(t *testing.T) {


### PR DESCRIPTION
The CacheWriter opens files to write to but exposes no method to close those open file handles. This leads to some issues in `spacemeshos/poet`. This PR adds a close method.