### PR TITLE
Flatten slices in SliceReadWriter

### DIFF
--- a/cache/readwriters/slice.go
+++ b/cache/readwriters/slice.go
@@ -9,19 +9,27 @@ import (
 const NodeSize = shared.NodeSize
 
 type SliceReadWriter struct {
-	slice    [][]byte
+	// a continuous memory for keeping nodes
+	slice []byte
+	// position in slice determined in nodes unit
+	// must be multiplied by `NodeSize`` to get its
+	// location in `slice`
 	position uint64
 }
 
 // A compile time check to ensure that SliceReadWriter fully implements LayerReadWriter.
 var _ shared.LayerReadWriter = (*SliceReadWriter)(nil)
 
+func (s *SliceReadWriter) width() uint64 {
+	return uint64(len(s.slice) / NodeSize)
+}
+
 func (s *SliceReadWriter) Width() (uint64, error) {
-	return uint64(len(s.slice)), nil
+	return s.width(), nil
 }
 
 func (s *SliceReadWriter) Seek(index uint64) error {
-	if index >= uint64(len(s.slice)) {
+	if index >= s.width() {
 		return io.EOF
 	}
 	s.position = index
@@ -29,17 +37,18 @@ func (s *SliceReadWriter) Seek(index uint64) error {
 }
 
 func (s *SliceReadWriter) ReadNext() ([]byte, error) {
-	if s.position >= uint64(len(s.slice)) {
+	if s.position >= s.width() {
 		return nil, io.EOF
 	}
 	value := make([]byte, NodeSize)
-	copy(value, s.slice[s.position])
+	index := s.position * NodeSize
+	copy(value, s.slice[index:index+NodeSize])
 	s.position++
 	return value, nil
 }
 
 func (s *SliceReadWriter) Append(p []byte) (n int, err error) {
-	s.slice = append(s.slice, p)
+	s.slice = append(s.slice, p...)
 	return len(p), nil
 }
 


### PR DESCRIPTION
# Motivation
Currently, `SliceReadWriter` keeps a `[][]byte` - a separate allocation for each tree node. It's suboptimal as it creates lots of small (32B) allocations. It's straightforward to rewrite it to keep a `[]byte` and index elements by `i * 32` to obtain the i-th element.

This PR changes `[][]byte` to `[]byte`.