### PR TITLE
Avoid allocations when building a tree

### DIFF
--- a/merkle.go
+++ b/merkle.go
@@ -134,22 +134,19 @@ func (t *Tree) AddLeaf(value []byte) error {
 
 			// A given node is required in the proof if and only if its parent is an ancestor
 			// of a leaf whose membership in the tree is being proven, but the given node isn't.
-			if lChild.OnProvenPath || rChild.OnProvenPath {
-				if !lChild.OnProvenPath {
-					copy := append([]byte(nil), lChild.value...)
-					t.proof = append(t.proof, copy)
-				}
-				if !rChild.OnProvenPath {
-					copy := append([]byte(nil), rChild.value...)
-					t.proof = append(t.proof, copy)
-				}
+			if rChild.OnProvenPath && !lChild.OnProvenPath {
+				copy := append([]byte(nil), lChild.value...)
+				t.proof = append(t.proof, copy)
+			}
+			if lChild.OnProvenPath && !rChild.OnProvenPath {
+				copy := append([]byte(nil), rChild.value...)
+				t.proof = append(t.proof, copy)
 			}
 
-			parent := t.calcParent(t.parentBuf[:0], lChild, rChild)
-			t.parentBuf = parent.value
+			n = t.calcParent(t.parentBuf[:0], lChild, rChild)
+			t.parentBuf = n.value
 
 			l.parking.value = l.parking.value[:0]
-			n = parent
 			err := l.ensureNextLayerExists(t.cacheWriter)
 			if err != nil {
 				return err

--- a/shared/types.go
+++ b/shared/types.go
@@ -1,6 +1,6 @@
 package shared
 
-type HashFunc func(lChild, rChild []byte) []byte
+type HashFunc func(buf, lChild, rChild []byte) []byte
 
 // LayerReadWriter is a combined reader-writer. Note that the Seek() method only belongs to the LayerReader interface
 // and does not affect the LayerWriter.

--- a/validation.go
+++ b/validation.go
@@ -104,7 +104,7 @@ func (v *Validator) CalcRoot(stopAtLayer uint) ([]byte, []ParkingSnapshot, error
 				subTreeSnapshots = nil
 			}
 		}
-		activeNode = v.Hash(lChild, rChild)
+		activeNode = v.Hash(nil, lChild, rChild)
 		activePos = activePos.parent()
 	}
 	return activeNode, parkingSnapshots, nil


### PR DESCRIPTION
### Reuse layer parking buffer
It avoids reallocating memory for layer parking by not discarding the parking when it is not needed anymore (it sets slice length to 0 instead of assigning a `nil`).

### Allow the user to reuse memory that was passed to `Tree::AddLeaf`. 
This is achieved by copying the passed data to the parking instead of just assigning the slice.

### Allow reusing memory for calculating the hash of a parent
This is achieved by changing the `shared.HashFunc` to accept a memory buffer into which the hash can be directly calculated. There is a permanent parent buffer (`Tree::parentBuf`) to keep the memory around.
