### PR TITLE
Allow configuring the in-memory buffer of FileReadWriter

### DIFF
--- a/cache/readwriters/file.go
+++ b/cache/readwriters/file.go
@@ -11,14 +11,17 @@ import (
 
 const OwnerReadWrite = 0o600
 
-func NewFileReadWriter(filename string) (*FileReadWriter, error) {
+// NewFileReadWriter creates a new file-based read-writer.
+// The `bufferSize` controls the in-memory buffer of the underlying
+// bufio.Writer.
+func NewFileReadWriter(filename string, bufferSize int) (*FileReadWriter, error) {
 	f, err := os.OpenFile(filename, os.O_RDWR|os.O_APPEND|os.O_CREATE, OwnerReadWrite)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file for disk read-writer: %v", err)
 	}
 	return &FileReadWriter{
 		f: f,
-		b: bufio.NewReadWriter(bufio.NewReader(f), bufio.NewWriter(f)),
+		b: bufio.NewReadWriter(bufio.NewReader(f), bufio.NewWriterSize(f, bufferSize)),
 	}, nil
 }
 

--- a/cache/readwriters/file_test.go
+++ b/cache/readwriters/file_test.go
@@ -15,7 +15,7 @@ func TestFileReadWriter(t *testing.T) {
 	r := require.New(t)
 
 	filename := "delete.me"
-	readWriter, err := NewFileReadWriter(filename)
+	readWriter, err := NewFileReadWriter(filename, 4096)
 	r.NoError(err)
 
 	defer func() {
@@ -62,7 +62,7 @@ func makeLabel(s string) []byte {
 }
 
 func TestConsistentEOF(t *testing.T) {
-	file, err := NewFileReadWriter(filepath.Join(t.TempDir(), "test"))
+	file, err := NewFileReadWriter(filepath.Join(t.TempDir(), "test"), 4096)
 	t.Cleanup(func() { file.Close() })
 	require.NoError(t, err)
 	slice := SliceReadWriter{}


### PR DESCRIPTION
The default buffer size for `bufio.Writer` is 4kB, which is too small for our needs. After this patch, the user will be in control of the buffer size.