### PR TITLE
Revert changes from #51

### DIFF
--- a/merkle.go
+++ b/merkle.go
@@ -104,9 +104,6 @@ type Tree struct {
 // AddLeaf incorporates a new leaf to the state of the tree. It updates the state required to eventually determine the
 // root of the tree and also updates the proof, if applicable.
 func (t *Tree) AddLeaf(value []byte) error {
-	if len(value) != NodeSize {
-		return fmt.Errorf("expected node size %d, got %d", NodeSize, len(value))
-	}
 	n := node{
 		value:        value,
 		OnProvenPath: t.leavesToProve.Pop(),

--- a/merkle_test.go
+++ b/merkle_test.go
@@ -466,31 +466,27 @@ func TestTree_GetParkedNodes(t *testing.T) {
 	tree, err := NewTreeBuilder().Build()
 	r.NoError(err)
 
-	leaf0 := [32]byte{}
-	r.NoError(tree.AddLeaf(leaf0[:]))
-	r.EqualValues([][]byte{leaf0[:]}, tree.GetParkedNodes(nil))
-
-	leaf1 := [32]byte{}
-	leaf1[0] = 1
-	r.NoError(tree.AddLeaf(leaf1[:]))
+	r.NoError(tree.AddLeaf([]byte{0}))
 	r.EqualValues(
-		[][]byte{{}, decode(r, "cb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6")},
+		[][]byte{{0}},
 		tree.GetParkedNodes(nil),
 	)
 
-	leaf2 := [32]byte{}
-	leaf2[0] = 2
-	r.NoError(tree.AddLeaf(leaf2[:]))
+	r.NoError(tree.AddLeaf([]byte{1}))
 	r.EqualValues(
-		[][]byte{leaf2[:], decode(r, "cb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6")},
+		[][]byte{{}, decode("b413f47d13ee2fe6c845b2ee141af81de858df4ec549a58b7970bb96645bc8d2")},
 		tree.GetParkedNodes(nil),
 	)
 
-	leaf3 := [32]byte{}
-	leaf3[0] = 3
-	r.NoError(tree.AddLeaf(leaf3[:]))
+	r.NoError(tree.AddLeaf([]byte{2}))
 	r.EqualValues(
-		[][]byte{{}, {}, decode(r, "ba94ffe7edabf26ef12736f8eb5ce74d15bedb6af61444ae2906e926b1a95084")},
+		[][]byte{{2}, decode("b413f47d13ee2fe6c845b2ee141af81de858df4ec549a58b7970bb96645bc8d2")},
+		tree.GetParkedNodes(nil),
+	)
+
+	r.NoError(tree.AddLeaf([]byte{3}))
+	r.EqualValues(
+		[][]byte{{}, {}, decode("7699a4fdd6b8b6908a344f73b8f05c8e1400f7253f544602c442ff5c65504b24")},
 		tree.GetParkedNodes(nil),
 	)
 }
@@ -498,38 +494,32 @@ func TestTree_GetParkedNodes(t *testing.T) {
 func TestTree_SetParkedNodes(t *testing.T) {
 	r := require.New(t)
 
-	node0 := [32]byte{}
-	leaf1 := [32]byte{}
-	leaf1[0] = 1
 	tree, err := NewTreeBuilder().Build()
 	r.NoError(err)
-	r.NoError(tree.SetParkedNodes([][]byte{node0[:]}))
-	r.NoError(tree.AddLeaf(leaf1[:]))
-	parkedNodes := [][]byte{{}, decode(r, "cb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6")}
+	r.NoError(tree.SetParkedNodes([][]byte{{0}}))
+	r.NoError(tree.AddLeaf([]byte{1}))
+	parkedNodes := [][]byte{{}, decode("b413f47d13ee2fe6c845b2ee141af81de858df4ec549a58b7970bb96645bc8d2")}
 	r.EqualValues(parkedNodes, tree.GetParkedNodes(nil))
 
-	leaf2 := [32]byte{}
-	leaf2[0] = 2
 	tree, err = NewTreeBuilder().Build()
 	r.NoError(err)
 	r.NoError(tree.SetParkedNodes(parkedNodes))
-	r.NoError(tree.AddLeaf(leaf2[:]))
-	parkedNodes = [][]byte{leaf2[:], decode(r, "cb592844121d926f1ca3ad4e1d6fb9d8e260ed6e3216361f7732e975a0e8bbf6")}
-	r.EqualValues(parkedNodes, tree.GetParkedNodes(nil))
+	r.NoError(tree.AddLeaf([]byte{2}))
+	parkedNodes = [][]byte{{2}, decode("b413f47d13ee2fe6c845b2ee141af81de858df4ec549a58b7970bb96645bc8d2")}
 
-	leaf3 := [32]byte{}
-	leaf3[0] = 3
 	tree, err = NewTreeBuilder().Build()
 	r.NoError(err)
 	r.NoError(tree.SetParkedNodes(parkedNodes))
-	r.NoError(tree.AddLeaf(leaf3[:]))
-	parkedNodes = [][]byte{{}, {}, decode(r, "ba94ffe7edabf26ef12736f8eb5ce74d15bedb6af61444ae2906e926b1a95084")}
+	r.NoError(tree.AddLeaf([]byte{3}))
+	parkedNodes = [][]byte{{}, {}, decode("7699a4fdd6b8b6908a344f73b8f05c8e1400f7253f544602c442ff5c65504b24")}
 	r.EqualValues(parkedNodes, tree.GetParkedNodes(nil))
 }
 
-func decode(r *require.Assertions, hexString string) []byte {
+func decode(hexString string) []byte {
 	hash, err := hex.DecodeString(hexString)
-	r.NoError(err)
+	if err != nil {
+		panic(err)
+	}
 	return hash
 }
 


### PR DESCRIPTION
I mistakenly assumed that leaves have to be 32 bytes like nodes in the merkle tree or validation will fail. Instead the reason validation fails was because the proof was altered in code that encoded and decoded it.